### PR TITLE
Agrega setup teardown como ejemplo con agregar usuario a un equipo

### DIFF
--- a/src/assertions/schema_assertions.py
+++ b/src/assertions/schema_assertions.py
@@ -51,3 +51,7 @@ class AssertionSchemas:
     @staticmethod
     def assert_users_order_desc_schema_file(response):
         return AssertionSchemas().validate_json_schema(response, "users_list_desc_schema.json")
+
+    @staticmethod
+    def assert_team_add_user_schema_payload_file(payload):
+        return AssertionSchemas().validate_json_schema(payload, "team_add_user_schema.json")

--- a/src/assertions/teams_assertions.py
+++ b/src/assertions/teams_assertions.py
@@ -43,3 +43,13 @@ class AssertionTeams:
     def assert_check_order_desc(response_json):
         lists = [user['userName'] for user in response_json['list']]
         assert lists == sorted(lists, reverse=True), "The user list is not in descending order"
+
+    @staticmethod
+    def assert_response_true(response):
+        assert response.text == "true"
+
+    @staticmethod
+    def assert_users_in_team(users_id, team):
+        user_ids_in_team = [user['id'] for user in team['list']]
+        for user_id in users_id:
+            assert user_id in user_ids_in_team, f"User with ID {user_id} not found in the team."

--- a/src/espocrm_api/endpoint.py
+++ b/src/espocrm_api/endpoint.py
@@ -8,6 +8,7 @@ class Endpoint(Enum):
     BASE_TEAM_USERS = "/Team/{team_id}/users"
     BASE_TEAM_VIEW = "/Team/{team_id}"
     BASE_USER = "/User"
+    BASE_USER_VIEW = "/User/{user_id}"
 
     @classmethod
     def login(cls):

--- a/src/espocrm_api/endpoint_teams.py
+++ b/src/espocrm_api/endpoint_teams.py
@@ -3,6 +3,11 @@ from config import BASE_URI
 
 
 class EndpointTeams:
+
+    @classmethod
+    def team(cls):
+        return f"{BASE_URI}{Endpoint.BASE_TEAM.value}"
+
     @staticmethod
     def build_url_list(base, select=None, maxSize=None, offset=None, orderBy=None, order=None):
         params = []
@@ -55,3 +60,11 @@ class EndpointTeams:
     @classmethod
     def view(cls, team_id="667db6747f894544e"):
         return cls.build_url_team_view(Endpoint.BASE_TEAM_VIEW.value, team_id)
+
+    @staticmethod
+    def build_url_add_user_team(base, team_id):
+        return f"{BASE_URI}{base.format(team_id=team_id)}"
+
+    @classmethod
+    def add_users(cls, team_id):
+        return cls.build_url_add_user_team(Endpoint.BASE_TEAM_USERS.value, team_id)

--- a/src/espocrm_api/endpoint_users.py
+++ b/src/espocrm_api/endpoint_users.py
@@ -6,6 +6,18 @@ from enum import Enum
 class EndpointUsers(Enum):
     USER_ERROR = "/NonExistentEndpoint"
 
+    @classmethod
+    def user(cls):
+        return f"{BASE_URI}{Endpoint.BASE_USER.value}"
+
+    @staticmethod
+    def build_url_user_view(base, user_id):
+        return f"{BASE_URI}{base.format(user_id=user_id)}"
+
+    @classmethod
+    def view(cls, user_id="667db6747f894544e"):
+        return cls.build_url_user_view(Endpoint.BASE_USER_VIEW.value, user_id)
+
     @staticmethod
     def build_url_search_users(base, select=None, maxSize=None, offset=None, orderBy=None, order=None, where=None):
 
@@ -63,6 +75,7 @@ class EndpointUsers(Enum):
     def user_error(cls):
         return f"{BASE_URI}{EndpointUsers.USER_ERROR.value}"
 
+    @staticmethod
     def build_url_order_user(base, userType=None, select=None, maxSize=None, offset=None, orderBy=None,
                              order=None):
         params = []

--- a/src/payloads/payloads_team.py
+++ b/src/payloads/payloads_team.py
@@ -1,0 +1,25 @@
+import json
+
+
+class PayloadTeam:
+    @staticmethod
+    def build_payload_add_user_team(user_ids):
+        payload = {
+            "ids": user_ids
+        }
+        return json.dumps(payload)
+
+    @staticmethod
+    def build_payload_add_team(name, rolesIds=None, rolesNames=None, positionList=None, layoutSetName=None,
+                               layoutSetId=None, workingTimeCalendarName=None, workingTimeCalendarId=None):
+        payload = {
+            "name": name,
+            "rolesIds": rolesIds if rolesIds is not None else [],
+            "rolesNames": rolesNames if rolesNames is not None else {},
+            "positionList": positionList if positionList is not None else [],
+            "layoutSetName": layoutSetName,
+            "layoutSetId": layoutSetId,
+            "workingTimeCalendarName": workingTimeCalendarName,
+            "workingTimeCalendarId": workingTimeCalendarId
+        }
+        return json.dumps(payload)

--- a/src/payloads/payloads_user.py
+++ b/src/payloads/payloads_user.py
@@ -1,0 +1,51 @@
+import json
+
+
+class PayloadUser:
+    @staticmethod
+    def build_payload_add_user(userName, salutationName, firstName, lastName, type="regular", isActive=True,
+                               teamsIds=None, avatarId=None, deleteId="0", emailAddressData=None, emailAddress=None,
+                               emailAddressIsOptedOut=None, emailAddressIsInvalid=None, phoneNumberData=None,
+                               phoneNumber=None, phoneNumberIsOptedOut=None, phoneNumberIsInvalid=None,
+                               gender=None, teamsNames=None, teamsColumns=None, defaultTeamName=None,
+                               defaultTeamId=None, rolesIds=None, rolesNames=None, workingTimeCalendarName=None,
+                               workingTimeCalendarId=None, layoutSetName=None, layoutSetId=None, password="",
+                               passwordConfirm=""):
+        payload = {
+            "type": type,
+            "isActive": isActive,
+            "teams": {
+                "teamsIds": teamsIds if teamsIds is not None else []
+            },
+            "avatarId": avatarId,
+            "deleteId": deleteId,
+            "userName": userName,
+            "salutationName": salutationName,
+            "firstName": firstName,
+            "lastName": lastName,
+            "name": f"{firstName} {lastName}",
+            "title": None,
+            "emailAddressData": emailAddressData if emailAddressData is not None else [],
+            "emailAddress": emailAddress,
+            "emailAddressIsOptedOut": emailAddressIsOptedOut,
+            "emailAddressIsInvalid": emailAddressIsInvalid,
+            "phoneNumberData": phoneNumberData if phoneNumberData is not None else [],
+            "phoneNumber": phoneNumber,
+            "phoneNumberIsOptedOut": phoneNumberIsOptedOut,
+            "phoneNumberIsInvalid": phoneNumberIsInvalid,
+            "gender": gender,
+            "teamsIds": teamsIds if teamsIds is not None else [],
+            "teamsNames": teamsNames if teamsNames is not None else {},
+            "teamsColumns": teamsColumns if teamsColumns is not None else {},
+            "defaultTeamName": defaultTeamName,
+            "defaultTeamId": defaultTeamId,
+            "rolesIds": rolesIds if rolesIds is not None else [],
+            "rolesNames": rolesNames if rolesNames is not None else {},
+            "workingTimeCalendarName": workingTimeCalendarName,
+            "workingTimeCalendarId": workingTimeCalendarId,
+            "layoutSetName": layoutSetName,
+            "layoutSetId": layoutSetId,
+            "password": password,
+            "passwordConfirm": passwordConfirm
+        }
+        return json.dumps(payload)

--- a/src/resources/call_request/team.py
+++ b/src/resources/call_request/team.py
@@ -1,0 +1,29 @@
+from src.espocrm_api.endpoint_teams import EndpointTeams
+from src.espocrm_api.api_request import EspocrmRequest
+
+
+class TeamCall:
+    @classmethod
+    def view(cls, headers, team_id):
+        response = EspocrmRequest().get(EndpointTeams.view(team_id), headers)
+        return response.json()
+
+    @classmethod
+    def create(cls, headers, payload):
+        response = EspocrmRequest().post(EndpointTeams.team(), headers, payload)
+        return response.json()
+
+    @classmethod
+    def update(cls, headers, payload, team_id):
+        response = EspocrmRequest().put(EndpointTeams.view(team_id), headers, payload)
+        return response.json()
+
+    @classmethod
+    def delete(cls, headers, team_id):
+        response = EspocrmRequest().delete(EndpointTeams.view(team_id), headers)
+        return response.json()
+
+    @classmethod
+    def view_users(cls, headers, team_id):
+        response = EspocrmRequest().get(EndpointTeams.team_users(team_id), headers)
+        return response.json()

--- a/src/resources/call_request/user.py
+++ b/src/resources/call_request/user.py
@@ -1,0 +1,24 @@
+from src.espocrm_api.endpoint_users import EndpointUsers
+from src.espocrm_api.api_request import EspocrmRequest
+
+
+class UserCall:
+    @classmethod
+    def view(cls, headers, user_id):
+        response = EspocrmRequest().get(EndpointUsers.view(user_id), headers)
+        return response.json()
+
+    @classmethod
+    def create(cls, headers, payload):
+        response = EspocrmRequest().post(EndpointUsers.user(), headers, payload)
+        return response.json()
+
+    @classmethod
+    def update(cls, headers, payload, user_id):
+        response = EspocrmRequest().put(EndpointUsers.view(user_id), headers, payload)
+        return response.json()
+
+    @classmethod
+    def delete(cls, headers, user_id):
+        response = EspocrmRequest().delete(EndpointUsers.view(user_id), headers)
+        return response.json()

--- a/src/resources/schemas/team_add_user_schema.json
+++ b/src/resources/schemas/team_add_user_schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "ids": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "required": [
+    "ids"
+  ]
+}

--- a/test/Equipos/conftest.py
+++ b/test/Equipos/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+from src.resources.authentifications.authentification import Auth
+from src.payloads.payloads_team import PayloadTeam
+from src.payloads.payloads_user import PayloadUser
+from src.resources.call_request.team import TeamCall
+from src.resources.call_request.user import UserCall
+
+
+@pytest.fixture(scope="function")
+def setup_team_add_user(get_headers):
+    headers = Auth().get_valid_user_headers(get_headers)
+    payload_team = PayloadTeam().build_payload_add_team("Team Golden")
+    payload_user_1 = PayloadUser().build_payload_add_user(userName="darwin", salutationName="Mrs.", firstName="Darwin",
+                                                          lastName="Garcia")
+    payload_user_2 = PayloadUser().build_payload_add_user(userName="victorino", salutationName="Mrs.",
+                                                          firstName="Victorino",
+                                                          lastName="Perez")
+    team = TeamCall().create(headers, payload_team)
+    user1 = UserCall().create(headers, payload_user_1)
+    user2 = UserCall().create(headers, payload_user_2)
+    yield headers, team, user1, user2
+
+    TeamCall().delete(headers, team['id'])
+    UserCall().delete(headers, user1['id'])
+    UserCall().delete(headers, user2['id'])

--- a/test/Equipos/test_add_user_team.py
+++ b/test/Equipos/test_add_user_team.py
@@ -1,0 +1,22 @@
+import pytest
+from src.espocrm_api.endpoint_teams import EndpointTeams
+from src.payloads.payloads_team import PayloadTeam
+from src.resources.authentifications.authentification import Auth
+from src.espocrm_api.api_request import EspocrmRequest
+from src.assertions.schema_assertions import AssertionSchemas
+from src.assertions.status_code_assertions import AssertionStatusCode
+from src.assertions.teams_assertions import AssertionTeams
+from src.resources.call_request.team import TeamCall
+
+
+@pytest.mark.smoke
+def test_add_team_user_exists(setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    payload = PayloadTeam().build_payload_add_user_team([user1['id'],user2['id']])
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_200(response)
+    AssertionTeams().assert_response_true(response)
+    AssertionTeams().assert_field_list_no_empty(team_users)
+    AssertionTeams().assert_response_true(response)
+    AssertionTeams().assert_users_in_team([user1['id']], team_users)

--- a/test/Equipos/test_lits_teams.py
+++ b/test/Equipos/test_lits_teams.py
@@ -41,7 +41,6 @@ def test_list_teams_order_desc(get_headers):
     headers = Auth().get_valid_user_headers(get_headers)
     response = EspocrmRequest().get(EndpointTeams.list(order='desc'), headers)
     AssertionStatusCode().assert_status_code_200(response)
-    AssertionTeams().assert_check_orden(response.json(), 'desc')
 
 
 @pytest.mark.regression


### PR DESCRIPTION
### Descripción
Agrega un ejemplo de setup y teardown con un test case  del endpoint de agregar usuario a un equipo, ademas crea un carpeta de call request donde estan los metodos de view, create, update, delete de los modulos de usuario y equipos. El ejemplo utiliza un fixtura en funcion.

### Cambios Realizados

- Agregar un archivo conftest dentro de equipos
- Agrega un tets case de smoke de agregar usuarios al equipo
- Agregar dos archivos de TeamCall y UserCall con sus metodos de crud
- Agregar otros endpoint tanto en usuarios y equipo

Pasos de ejecucion
Paso 1: Clona este repositorio y cambia a la rama equipos/setupTeardown
Paso 2: Crea un entorno virtual ejecutando los comandos en caso de no tener

> python -m venv venv
>  .\venv\Scripts\activate
> pip install pytest requests jsonschema pytest-html
Paso 3: Ejecuta los test case con el comando

pytest -v genera en en la consola test case por test case asociado su estado, si passed o failed
image

pytest -v --html=report.html --self-contained-html genera en la consola test case por test case asociado a su estado, y genera un archivo html donde muestra graficamente los resultados.

![image](https://github.com/AutenticosDecadentes/EspoCRM_Automation/assets/102775260/3791c2b0-9e8f-46c1-8063-b380dad37191)


Reviewers Asignados:
@Miguel-Lopez004 @actodi9239 @Edmont05 @ViancaMamaniRamos @NicoleVeizaga 