### PR TITLE
Agrega test case con setup de add user al team

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@ import base64
 from config import X_Api_Key
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def get_headers():
     def _get_headers(username, password, additional_params=None):
         espo_authorization = encoded(username, password)

--- a/src/assertions/schema_assertions.py
+++ b/src/assertions/schema_assertions.py
@@ -54,4 +54,6 @@ class AssertionSchemas:
 
     @staticmethod
     def assert_team_add_user_schema_payload_file(payload):
+        if isinstance(payload, str):
+            payload = json.loads(payload)
         return AssertionSchemas().validate_json_schema(payload, "team_add_user_schema.json")

--- a/src/assertions/teams_assertions.py
+++ b/src/assertions/teams_assertions.py
@@ -49,7 +49,16 @@ class AssertionTeams:
         assert response.text == "true"
 
     @staticmethod
+    def assert_response_false(response):
+        assert response.text == "false"
+
+    @staticmethod
     def assert_users_in_team(users_id, team):
         user_ids_in_team = [user['id'] for user in team['list']]
         for user_id in users_id:
             assert user_id in user_ids_in_team, f"User with ID {user_id} not found in the team."
+
+    @staticmethod
+    def assert_user_not_in_team(user_id, team):
+        user_ids_in_team = [user['id'] for user in team['list']]
+        assert user_id not in user_ids_in_team, f"User with ID {user_id} found in the team."

--- a/src/resources/schemas/team_add_user_schema.json
+++ b/src/resources/schemas/team_add_user_schema.json
@@ -3,11 +3,9 @@
   "properties": {
     "ids": {
       "type": "array",
-      "items": [
-        {
-          "type": "string"
-        }
-      ]
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [

--- a/test/Equipos/conftest.py
+++ b/test/Equipos/conftest.py
@@ -6,7 +6,7 @@ from src.resources.call_request.team import TeamCall
 from src.resources.call_request.user import UserCall
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def setup_team_add_user(get_headers):
     headers = Auth().get_valid_user_headers(get_headers)
     payload_team = PayloadTeam().build_payload_add_team("Team Golden")
@@ -23,3 +23,13 @@ def setup_team_add_user(get_headers):
     TeamCall().delete(headers, team['id'])
     UserCall().delete(headers, user1['id'])
     UserCall().delete(headers, user2['id'])
+
+
+@pytest.fixture(scope="module")
+def setup_create_user(get_headers):
+    headers = Auth().get_valid_user_headers(get_headers)
+    payload_user_1 = PayloadUser().build_payload_add_user(userName="charles", salutationName="Mrs.",
+                                                          firstName="Charles",
+                                                          lastName="James")
+    user = UserCall().create(headers, payload_user_1)
+    yield user

--- a/test/Equipos/test_add_user_team.py
+++ b/test/Equipos/test_add_user_team.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest, random, string
 from src.espocrm_api.endpoint_teams import EndpointTeams
 from src.payloads.payloads_team import PayloadTeam
 from src.resources.authentifications.authentification import Auth
@@ -7,16 +7,113 @@ from src.assertions.schema_assertions import AssertionSchemas
 from src.assertions.status_code_assertions import AssertionStatusCode
 from src.assertions.teams_assertions import AssertionTeams
 from src.resources.call_request.team import TeamCall
+from src.resources.call_request.user import UserCall
 
 
 @pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.functional
 def test_add_team_user_exists(setup_team_add_user):
     headers, team, user1, user2 = setup_team_add_user
-    payload = PayloadTeam().build_payload_add_user_team([user1['id'],user2['id']])
+    payload = PayloadTeam().build_payload_add_user_team([user1['id']])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
     response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
     team_users = TeamCall().view_users(headers, team['id'])
     AssertionStatusCode().assert_status_code_200(response)
     AssertionTeams().assert_response_true(response)
     AssertionTeams().assert_field_list_no_empty(team_users)
-    AssertionTeams().assert_response_true(response)
     AssertionTeams().assert_users_in_team([user1['id']], team_users)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+@pytest.mark.smoke
+def test_add_team_multi_users(setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    payload = PayloadTeam().build_payload_add_user_team([user1['id'], user2['id']])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_200(response)
+    AssertionTeams().assert_response_true(response)
+    AssertionTeams().assert_field_list_no_empty(team_users)
+    AssertionTeams().assert_users_in_team([user1['id'], user2['id']], team_users)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+@pytest.mark.smoke
+def test_add_team_user_invalid_authentication(get_headers, setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    headers = Auth().get_invalid_user_headers(get_headers)
+    payload = PayloadTeam().build_payload_add_user_team([user1['id'], user2['id']])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_401(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_add_team_user_invalid(setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    user_id_invalid = ''.join(random.choices(string.ascii_letters + string.digits, k=17))
+    payload = PayloadTeam().build_payload_add_user_team([user_id_invalid])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_empty(response.text)
+    AssertionTeams().assert_user_not_in_team([user_id_invalid], team_users)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_add_team_user_exist(setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    payload = PayloadTeam().build_payload_add_user_team([user1['id']])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionTeams().assert_users_in_team([user1['id']], team_users)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_200(response)
+    AssertionTeams().assert_response_true(response)
+    AssertionTeams().assert_field_list_no_empty(team_users)
+    AssertionTeams().assert_users_in_team([user1['id']], team_users)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_add_team_not_exists(get_headers):
+    headers = Auth().get_valid_user_headers(get_headers)
+    team_id_invalid = ''.join(random.choices(string.ascii_letters + string.digits, k=17))
+    user_id_invalid = ''.join(random.choices(string.ascii_letters + string.digits, k=17))
+    payload = PayloadTeam().build_payload_add_user_team([user_id_invalid])
+    AssertionSchemas().assert_team_add_user_schema_payload_file(payload)
+    response = EspocrmRequest().post(EndpointTeams.add_users(team_id_invalid), headers, payload)
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_add_user_empty_payload(setup_team_add_user):
+    headers, team, user1, user2 = setup_team_add_user
+    payload = PayloadTeam().build_payload_add_user_team("")
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_200(response)
+    AssertionTeams().assert_response_false(response)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_add_deleted_user(setup_team_add_user, setup_create_user):
+    headers, team, user1, user2 = setup_team_add_user
+    user3 = setup_create_user
+    UserCall().delete(headers, user3['id'])
+    payload = PayloadTeam().build_payload_add_user_team([user3["id"]])
+    response = EspocrmRequest().post(EndpointTeams.add_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_empty(response.text)

--- a/test/Equipos/test_lits_teams.py
+++ b/test/Equipos/test_lits_teams.py
@@ -19,7 +19,6 @@ def test_list_teams_with_data(get_headers):
 
 @pytest.mark.regression
 @pytest.mark.functional
-@pytest.mark.prueba
 def test_list_teams_order_asc(get_headers):
     headers = Auth().get_valid_user_headers(get_headers)
     response = EspocrmRequest().get(EndpointTeams.list(order='asc'), headers)


### PR DESCRIPTION
### Descripción
Agrega test case sobre agregar un usuario al team

### Cambios Realizados
Modificar y agreagr un metedo conftest dentro de equipos
Agrega un tets case de smoke de agregar usuarios al equipo

### Pasos de ejecucion
Paso 1: Clona este repositorio y cambia a la rama equipos/setupTeardown
Paso 2: Crea un entorno virtual ejecutando los comandos en caso de no tener

python -m venv venv
.\venv\Scripts\activate
pip install pytest requests jsonschema pytest-html
Paso 3: Ejecuta los test case con el comando

pytest -v genera en en la consola test case por test case asociado su estado, si passed o failed
image

pytest -v --html=report.html --self-contained-html genera en la consola test case por test case asociado a su estado, y genera un archivo html donde muestra graficamente los resultados.

![image](https://github.com/AutenticosDecadentes/EspoCRM_Automation/assets/102775260/4a0c5a51-c648-4b16-917e-e9015d02f8c6)

Reviewers Asignados:
@Miguel-Lopez004 @actodi9239 