### PR TITLE
Agrega test case de desvincular un usuario del team

### DIFF
--- a/src/assertions/schema_assertions.py
+++ b/src/assertions/schema_assertions.py
@@ -67,3 +67,9 @@ class AssertionSchemas:
         if isinstance(payload, str):
             payload = json.loads(payload)
         return AssertionSchemas().validate_json_schema(payload, "team_delete_multiple_team_schema.json")
+
+    @staticmethod
+    def assert_team_unlink_user_schema_payload_file(payload):
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return AssertionSchemas().validate_json_schema(payload, "team_unlink_user_schema.json")

--- a/src/espocrm_api/endpoint_teams.py
+++ b/src/espocrm_api/endpoint_teams.py
@@ -68,3 +68,7 @@ class EndpointTeams:
     @classmethod
     def add_users(cls, team_id):
         return cls.build_url_add_user_team(Endpoint.BASE_TEAM_USERS.value, team_id)
+
+    @classmethod
+    def delete_users(cls, team_id):
+        return cls.build_url_add_user_team(Endpoint.BASE_TEAM_USERS.value, team_id)

--- a/src/payloads/payloads_team.py
+++ b/src/payloads/payloads_team.py
@@ -10,6 +10,13 @@ class PayloadTeam:
         return json.dumps(payload)
 
     @staticmethod
+    def build_payload_unlink_user_team(user_id):
+        payload = {
+            "id": user_id
+        }
+        return json.dumps(payload)
+
+    @staticmethod
     def build_payload_add_team(name, rolesIds=None, rolesNames=None, positionList=None, layoutSetName=None,
                                layoutSetId=None, workingTimeCalendarName=None, workingTimeCalendarId=None):
         payload = {

--- a/src/resources/call_request/team.py
+++ b/src/resources/call_request/team.py
@@ -27,3 +27,8 @@ class TeamCall:
     def view_users(cls, headers, team_id):
         response = EspocrmRequest().get(EndpointTeams.team_users(team_id), headers)
         return response.json()
+
+    @classmethod
+    def add_user(cls, headers, payload, team_id):
+        response = EspocrmRequest().post(EndpointTeams.add_users(team_id), headers, payload)
+        return response.json()

--- a/src/resources/schemas/team_unlink_user_schema.json
+++ b/src/resources/schemas/team_unlink_user_schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/test/Equipos/conftest.py
+++ b/test/Equipos/conftest.py
@@ -6,7 +6,6 @@ from src.resources.call_request.team import TeamCall
 from src.resources.call_request.user import UserCall
 
 
-
 @pytest.fixture(scope="module")
 def setup_team_add_user(get_headers):
     headers = Auth().get_valid_user_headers(get_headers)
@@ -25,6 +24,29 @@ def setup_team_add_user(get_headers):
     UserCall().delete(headers, user1['id'])
     UserCall().delete(headers, user2['id'])
 
+
+@pytest.fixture(scope="module")
+def setup_team_unlink_user(get_headers):
+    headers = Auth().get_valid_user_headers(get_headers)
+    payload_team = PayloadTeam().build_payload_add_team("Team Red")
+    payload_user_1 = PayloadUser().build_payload_add_user(userName="javier", salutationName="Mrs.", firstName="Javi",
+                                                          lastName="Garcia")
+
+    payload_user_2 = PayloadUser().build_payload_add_user(userName="ronald", salutationName="Mrs.",
+                                                          firstName="Ronald",
+                                                          lastName="Perez")
+    team = TeamCall().create(headers, payload_team)
+    user1 = UserCall().create(headers, payload_user_1)
+    user2 = UserCall().create(headers, payload_user_2)
+    payload = PayloadTeam().build_payload_add_user_team([user1['id'], user2['id']])
+    TeamCall().add_user(headers, payload, team['id'])
+    yield headers, team, user1, user2
+
+    TeamCall().delete(headers, team['id'])
+    UserCall().delete(headers, user1['id'])
+    UserCall().delete(headers, user2['id'])
+
+
 @pytest.fixture(scope="module")
 def setup_create_user(get_headers):
     headers = Auth().get_valid_user_headers(get_headers)
@@ -33,6 +55,7 @@ def setup_create_user(get_headers):
                                                           lastName="James")
     user = UserCall().create(headers, payload_user_1)
     yield user
+
 
 @pytest.fixture(scope="function")
 def setup_add_team(get_headers):
@@ -52,6 +75,7 @@ def setup_team_delete_multiple_team(get_headers):
     team = TeamCall().create(headers, payload_team)
     team2 = TeamCall().create(headers, payload_team2)
     yield headers, team, team2
+
 
 @pytest.fixture(scope="module")
 def setup_team_delete_multiple_one_team(get_headers):

--- a/test/Equipos/test_unlink_user_team.py
+++ b/test/Equipos/test_unlink_user_team.py
@@ -1,0 +1,97 @@
+import pytest, random, string
+from src.espocrm_api.endpoint_teams import EndpointTeams
+from src.payloads.payloads_team import PayloadTeam
+from src.resources.authentifications.authentification import Auth
+from src.espocrm_api.api_request import EspocrmRequest
+from src.assertions.schema_assertions import AssertionSchemas
+from src.assertions.status_code_assertions import AssertionStatusCode
+from src.assertions.teams_assertions import AssertionTeams
+from src.resources.call_request.team import TeamCall
+from src.resources.call_request.user import UserCall
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_team_user_exists(setup_team_unlink_user):
+    headers, team, user1, user2 = setup_team_unlink_user
+    payload = PayloadTeam().build_payload_unlink_user_team(user1['id'])
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_200(response)
+    AssertionTeams().assert_response_true(response)
+    AssertionTeams().assert_user_not_in_team([user1['id']], team_users)
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_team_user_invalid_authentication(setup_team_unlink_user, get_headers):
+    headers, team, user1, user2 = setup_team_unlink_user
+    headers = Auth().get_invalid_user_headers(get_headers)
+    payload = PayloadTeam().build_payload_unlink_user_team(user1['id'])
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_401(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_team_not_exits(setup_team_unlink_user):
+    headers, team, user1, user2 = setup_team_unlink_user
+    team_id_invalid = ''.join(random.choices(string.ascii_letters + string.digits, k=17))
+    payload = PayloadTeam().build_payload_unlink_user_team(user1['id'])
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team_id_invalid), headers, payload)
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_user_not_exits(setup_team_unlink_user):
+    headers, team, user1, user2 = setup_team_unlink_user
+    user_id_invalid = ''.join(random.choices(string.ascii_letters + string.digits, k=17))
+    payload = PayloadTeam().build_payload_unlink_user_team(user_id_invalid)
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_user_exist_in_team(setup_team_unlink_user):
+    headers, team, user1, user2 = setup_team_unlink_user
+    payload = PayloadTeam().build_payload_unlink_user_team(user2['id'])
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    team_users = TeamCall().view_users(headers, team['id'])
+    AssertionStatusCode().assert_status_code_404(response)
+    AssertionTeams().assert_response_false(response)
+    AssertionTeams().assert_user_not_in_team([user1['id']], team_users)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_team_user_unauthorized(setup_team_unlink_user, get_headers):
+    headers, team, user1, user2 = setup_team_unlink_user
+    headers = Auth().get_unauthorized_teams_user_headers(get_headers)
+    payload = PayloadTeam().build_payload_unlink_user_team(user1['id'])
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_403(response)
+    AssertionTeams().assert_response_empty(response.text)
+
+
+@pytest.mark.regression
+@pytest.mark.functional
+def test_unlink_team_user_id_empty(setup_team_unlink_user):
+    headers, team, user1, user2 = setup_team_unlink_user
+    payload = PayloadTeam().build_payload_unlink_user_team("")
+    AssertionSchemas().assert_team_unlink_user_schema_payload_file(payload)
+    response = EspocrmRequest().delete(EndpointTeams.delete_users(team['id']), headers, payload)
+    AssertionStatusCode().assert_status_code_400(response)
+    AssertionTeams().assert_response_empty(response.text)


### PR DESCRIPTION
### Descripción
Agrega test case sobre sobre desvincular un usuario del team, y todo lo que conlleva con ello. Como ser los schemas, el setup y el CallTeam de agregar usuarios al tea,,

Cambios Realizados
Modificar y agreagr un metedo conftest dentro de equipos, para el setup de desvincular users del team
Agrega test case de smoke, regressesion(functional)

Pasos de ejecucion
Paso 1: Clona este repositorio y cambia a la rama AD-24_desvincular_usuario
Paso 2: Crea un entorno virtual ejecutando los comandos en caso de no tener

```
> python -m venv venv
> .\venv\Scripts\activate
> pip install pytest requests jsonschema pytest-html
```


Paso 3: Ejecuta los test case con el comando

pytest -v genera en en la consola test case por test case asociado su estado, si passed o failed

![image](https://github.com/AutenticosDecadentes/EspoCRM_Automation/assets/102775260/41200057-b50b-4eef-9933-4ae71e7c1274)

pytest -v --html=report.html --self-contained-html genera en la consola test case por test case asociado a su estado, y genera un archivo html donde muestra graficamente los resultados.
